### PR TITLE
Support files with spaces in their names

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -204,9 +204,13 @@ makeFilesMatchingPrefixes =
       rootDir <- getGitRootDir
       let rootRelativeFiles =
               filterM (fmap not . isDirectory) . map (rootDir </>)
+      let decode x =
+              case reads x of
+              [(r, "")] -> r
+              _ -> x
       let firstMatchingPrefix :: [String] -> String -> Maybe String
           firstMatchingPrefix prefixes =
-              asum . traverse unprefix prefixes
+              fmap decode . asum . traverse unprefix prefixes
       let filesMatchingPrefixes :: [String] -> IO [FilePath]
           filesMatchingPrefixes prefixes =
               rootRelativeFiles . mapMaybe (firstMatchingPrefix prefixes)


### PR DESCRIPTION
"git status --porcelain" may return output such as

    DU "file with spaces in name"

(tested with `git version 2.30.2`)

We need to remove the quotation marks when parsing those.