### PR TITLE
Permit zdiff3 conflict style

### DIFF
--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -40,7 +40,7 @@ setConflictStyle =
 checkConflictStyle :: Options -> IO ()
 checkConflictStyle opts =
     do  conflictStyle <- getConflictStyle
-        when (conflictStyle /= "diff3") $
+        unless (conflictStyle `elem` ["diff3", "zdiff3"]) $
             do  unless (shouldSetConflictStyle opts) $
                     fail $ concat
                     [ "merge.conflictstyle must be diff3 but is "


### PR DESCRIPTION
Adds support for zdiff3 conflict style

When user asks to set conflict style we still use 'diff3' because
'zdiff3' is very new. (Git 2.5.0+)

Only lightly tested (manually), but AFAIK the zdiff3 conflict style should be identical to the diff3 in every way except that it should produce smaller regions.

EDIT: Just to add: I will be running with this for a few days at least to give it more testing, so no rush in merging or anything.