### PR TITLE
Modernize project with OverloadedRecordDot

### DIFF
--- a/src/Conflict.hs
+++ b/src/Conflict.hs
@@ -25,13 +25,13 @@ data Sides a = Sides
     deriving Applicative via Generically1 Sides
 
 data Conflict = Conflict
-    { cMarkers   :: Sides (LineNo, String) -- The markers at the beginning of sections
-    , cMarkerEnd :: (LineNo, String)       -- The ">>>>>>>...." marker at the end of the conflict
-    , cBodies    :: Sides [String]
+    { markers   :: Sides (LineNo, String) -- The markers at the beginning of sections
+    , markerEnd :: (LineNo, String)       -- The ">>>>>>>...." marker at the end of the conflict
+    , bodies    :: Sides [String]
     } deriving (Show)
 
 setBodies :: (Sides [String] -> Sides [String]) -> Conflict -> Conflict
-setBodies f c@Conflict{cBodies} = c{cBodies = f cBodies}
+setBodies f c@Conflict{bodies} = c{bodies = f bodies}
 
 setEachBody :: ([String] -> [String]) -> Conflict -> Conflict
 setEachBody = setBodies . fmap
@@ -40,8 +40,8 @@ setStrings :: (String -> String) -> Conflict -> Conflict
 setStrings = setEachBody . map
 
 prettyLines :: Conflict -> [String]
-prettyLines Conflict{cMarkers, cMarkerEnd, cBodies} =
-    concat ((:) <$> (snd <$> cMarkers) <*> cBodies) <> [snd cMarkerEnd]
+prettyLines Conflict{markers, markerEnd, bodies} =
+    concat ((:) <$> (snd <$> markers) <*> bodies) <> [snd markerEnd]
 
 pretty :: Conflict -> String
 pretty = unlines . prettyLines
@@ -95,9 +95,9 @@ parseConflict markerA =
         (linesBase, markerB)    <- readUpToMarker '=' markerCount
         (linesB   , markerEnd)  <- readUpToMarker '>' markerCount
         pure Conflict
-            { cMarkers    = Sides markerA markerBase markerB
-            , cMarkerEnd  = markerEnd
-            , cBodies     = fmap snd <$> Sides linesA linesBase linesB
+            { markers    = Sides markerA markerBase markerB
+            , markerEnd  = markerEnd
+            , bodies     = fmap snd <$> Sides linesA linesBase linesB
             }
     where
         markerCount = Just (length (takeWhile (== '<') (snd markerA)))

--- a/src/Conflict.hs
+++ b/src/Conflict.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, NoImplicitPrelude, DeriveTraversable, NamedFieldPuns, DerivingVia, DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts, NoImplicitPrelude, DeriveTraversable, NamedFieldPuns, DerivingVia, DeriveGeneric, OverloadedRecordDot #-}
 
 module Conflict
     ( Conflict(..), Sides(..), LineNo
@@ -31,7 +31,7 @@ data Conflict = Conflict
     } deriving (Show)
 
 setBodies :: (Sides [String] -> Sides [String]) -> Conflict -> Conflict
-setBodies f c@Conflict{bodies} = c{bodies = f bodies}
+setBodies f c = c{bodies = f c.bodies}
 
 setEachBody :: ([String] -> [String]) -> Conflict -> Conflict
 setEachBody = setBodies . fmap
@@ -40,8 +40,8 @@ setStrings :: (String -> String) -> Conflict -> Conflict
 setStrings = setEachBody . map
 
 prettyLines :: Conflict -> [String]
-prettyLines Conflict{markers, markerEnd, bodies} =
-    concat ((:) <$> (snd <$> markers) <*> bodies) <> [snd markerEnd]
+prettyLines c =
+    concat ((:) <$> (snd <$> c.markers) <*> c.bodies) <> [snd c.markerEnd]
 
 pretty :: Conflict -> String
 pretty = unlines . prettyLines
@@ -96,7 +96,7 @@ parseConflict markerA =
         (linesB   , markerEnd)  <- readUpToMarker '>' markerCount
         pure Conflict
             { markers    = Sides markerA markerBase markerB
-            , markerEnd  = markerEnd
+            , markerEnd
             , bodies     = fmap snd <$> Sides linesA linesBase linesB
             }
     where

--- a/src/Conflict.hs
+++ b/src/Conflict.hs
@@ -9,7 +9,6 @@ module Conflict
 
 import Control.Monad.State (MonadState, state, evalStateT)
 import Control.Monad.Writer (runWriter, tell)
-import Data.Functor.Identity (Identity(..))
 import Data.Maybe (fromMaybe)
 import Generic.Data (Generically1(..))
 import GHC.Generics (Generic1)
@@ -31,13 +30,8 @@ data Conflict = Conflict
     , cBodies    :: Sides [String]
     } deriving (Show)
 
--- traversal
-bodies :: Applicative f => (Sides [String] -> f (Sides [String])) -> Conflict -> f Conflict
-bodies f c@Conflict{cBodies} = (\x -> c{cBodies = x}) <$> f cBodies
-
--- setter:
 setBodies :: (Sides [String] -> Sides [String]) -> Conflict -> Conflict
-setBodies f = runIdentity . bodies (Identity . f)
+setBodies f c@Conflict{cBodies} = c{cBodies = f cBodies}
 
 setEachBody :: ([String] -> [String]) -> Conflict -> Conflict
 setEachBody = setBodies . fmap

--- a/src/Environment.hs
+++ b/src/Environment.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude, OverloadedRecordDot #-}
 
 module Environment
     ( checkConflictStyle, shouldUseColorByTerminal, openEditor
@@ -41,7 +41,7 @@ checkConflictStyle :: Options -> IO ()
 checkConflictStyle opts =
     do  conflictStyle <- getConflictStyle
         unless (conflictStyle `elem` ["diff3", "zdiff3"]) $
-            do  unless (shouldSetConflictStyle opts) $
+            do  unless opts.shouldSetConflictStyle $
                     fail $ concat
                     [ "merge.conflictstyle must be diff3 but is "
                     , show conflictStyle
@@ -59,7 +59,7 @@ checkConflictStyle opts =
 
 openEditor :: Options -> FilePath -> IO ()
 openEditor opts path
-    | shouldUseEditor opts =
+    | opts.shouldUseEditor =
         do  editor <- getEnv "EDITOR"
             callProcess editor [path]
     | otherwise = pure ()

--- a/src/Resolution.hs
+++ b/src/Resolution.hs
@@ -28,8 +28,8 @@ resolveGen (Sides a base b)
     | otherwise = Nothing
 
 resolveConflict :: Conflict -> Resolution
-resolveConflict conflict@Conflict {cBodies} =
-    case resolveGen cBodies of
+resolveConflict conflict@Conflict {bodies} =
+    case resolveGen bodies of
     Just r -> Resolution $ unlines r
     Nothing
         | matchTop > 0 || matchBottom > 0 ->
@@ -39,7 +39,7 @@ resolveConflict conflict@Conflict {cBodies} =
             takeEnd matchBottom sideA
         | otherwise -> NoResolution
     where
-        Sides {sideA, sideBase, sideB} = cBodies
+        Sides {sideA, sideBase, sideB} = bodies
         match base a b
             | null base = lengthOfCommonPrefix a b
             | otherwise = minimum $ map (lengthOfCommonPrefix base) [a, b]
@@ -54,9 +54,9 @@ lengthOfCommonPrefix :: Eq a => [a] -> [a] -> Int
 lengthOfCommonPrefix x y = length $ takeWhile id $ zipWith (==) x y
 
 data Result = Result
-    { _resolvedSuccessfully :: !Int
-    , _reducedConflicts :: !Int
-    , _failedToResolve :: !Int
+    { resolvedSuccessfully :: !Int
+    , reducedConflicts :: !Int
+    , failedToResolve :: !Int
     }
 
 fullySuccessful :: Result -> Bool
@@ -68,8 +68,8 @@ instance Semigroup Result where
 instance Monoid Result where mempty = Result 0 0 0
 
 data NewContent = NewContent
-    { _result :: !Result
-    , _newContent :: !String
+    { result :: !Result
+    , newContent :: !String
     }
     deriving Generic
     deriving (Semigroup, Monoid) via Generically NewContent
@@ -112,8 +112,8 @@ allSame (x:y:rest) = x == y && allSame (y:rest)
 allSame _ = True
 
 lineBreakFix :: Conflict -> Conflict
-lineBreakFix c@Conflict{cBodies}
-    | any null (toList cBodies)
+lineBreakFix c@Conflict{bodies}
+    | any null (toList bodies)
     || allSame (toList endings) = c
     | otherwise =
         case resolveGen endings of
@@ -121,7 +121,7 @@ lineBreakFix c@Conflict{cBodies}
         Just CRLF -> Conflict.setStrings makeCr c
         _ -> c
     where
-        endings = fmap lineEndings cBodies
+        endings = fmap lineEndings bodies
         removeCr x@(_:_) | last x == '\r' = init x
         removeCr x = x
         makeCr x@(_:_) | last x == '\r' = x

--- a/src/SideDiff.hs
+++ b/src/SideDiff.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude, NamedFieldPuns #-}
+{-# LANGUAGE NoImplicitPrelude, OverloadedRecordDot #-}
 
 module SideDiff
     ( SideDiff, Side(..)
@@ -16,18 +16,12 @@ data Side = A | B
 type SideDiff = (Side, (LineNo, String), [Diff String])
 
 getConflictDiffs :: Conflict -> [SideDiff]
-getConflictDiffs Conflict{markers, markerEnd, bodies} =
-    [ (A, markerA, getDiff bodyBase bodyA)
-    | not (null bodyA) ] ++
-    [ (B, (fst markerB, snd markerEnd), getDiff bodyBase bodyB)
-    | not (null bodyB) ]
-    where
-        Sides markerA _ markerB = markers
-        Sides bodyA bodyBase bodyB = bodies
+getConflictDiffs c =
+    [ (A, c.markers.sideA, getDiff c.bodies.sideBase c.bodies.sideA)
+    | not (null c.bodies.sideA) ] ++
+    [ (B, (fst c.markers.sideB, snd c.markerEnd), getDiff c.bodies.sideBase c.bodies.sideB)
+    | not (null c.bodies.sideB) ]
 
 getConflictDiff2s :: Conflict -> ((LineNo, String), (LineNo, String), [Diff String])
-getConflictDiff2s Conflict{markers, bodies} =
-    (markerA, markerB, getDiff bodyA bodyB)
-    where
-        Sides markerA _ markerB = markers
-        Sides bodyA _ bodyB = bodies
+getConflictDiff2s c =
+    (c.markers.sideA, c.markers.sideB, getDiff c.bodies.sideA c.bodies.sideB)

--- a/src/SideDiff.hs
+++ b/src/SideDiff.hs
@@ -16,18 +16,18 @@ data Side = A | B
 type SideDiff = (Side, (LineNo, String), [Diff String])
 
 getConflictDiffs :: Conflict -> [SideDiff]
-getConflictDiffs Conflict{cMarkers, cMarkerEnd, cBodies} =
+getConflictDiffs Conflict{markers, markerEnd, bodies} =
     [ (A, markerA, getDiff bodyBase bodyA)
     | not (null bodyA) ] ++
-    [ (B, (fst markerB, snd cMarkerEnd), getDiff bodyBase bodyB)
+    [ (B, (fst markerB, snd markerEnd), getDiff bodyBase bodyB)
     | not (null bodyB) ]
     where
-        Sides markerA _ markerB = cMarkers
-        Sides bodyA bodyBase bodyB = cBodies
+        Sides markerA _ markerB = markers
+        Sides bodyA bodyBase bodyB = bodies
 
 getConflictDiff2s :: Conflict -> ((LineNo, String), (LineNo, String), [Diff String])
-getConflictDiff2s Conflict{cMarkers, cBodies} =
+getConflictDiff2s Conflict{markers, bodies} =
     (markerA, markerB, getDiff bodyA bodyB)
     where
-        Sides markerA _ markerB = cMarkers
-        Sides bodyA _ bodyB = cBodies
+        Sides markerA _ markerB = markers
+        Sides bodyA _ bodyB = bodies

--- a/src/SideDiff.hs
+++ b/src/SideDiff.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE NoImplicitPrelude, OverloadedRecordDot #-}
 
 module SideDiff
-    ( SideDiff, Side(..)
+    ( SideDiff(..), Side(..)
     , getConflictDiffs, getConflictDiff2s
     ) where
 
-import           Conflict (Conflict(..), Sides(..), LineNo)
+import           Conflict (Conflict(..), Sides(..), SrcContent(..))
 import           Data.Algorithm.Diff (Diff, getDiff)
 
 import           Prelude.Compat
@@ -13,15 +13,19 @@ import           Prelude.Compat
 data Side = A | B
     deriving (Eq, Ord, Show)
 
-type SideDiff = (Side, (LineNo, String), [Diff String])
+data SideDiff = SideDiff
+    { side :: Side
+    , marker :: SrcContent
+    , diff :: [Diff String]
+    }
 
 getConflictDiffs :: Conflict -> [SideDiff]
 getConflictDiffs c =
-    [ (A, c.markers.sideA, getDiff c.bodies.sideBase c.bodies.sideA)
+    [ SideDiff A c.markers.sideA (getDiff c.bodies.sideBase c.bodies.sideA)
     | not (null c.bodies.sideA) ] ++
-    [ (B, (fst c.markers.sideB, snd c.markerEnd), getDiff c.bodies.sideBase c.bodies.sideB)
+    [ SideDiff B (SrcContent c.markers.sideB.lineNo c.markerEnd.content) (getDiff c.bodies.sideBase c.bodies.sideB)
     | not (null c.bodies.sideB) ]
 
-getConflictDiff2s :: Conflict -> ((LineNo, String), (LineNo, String), [Diff String])
+getConflictDiff2s :: Conflict -> (SrcContent, SrcContent, [Diff String])
 getConflictDiff2s c =
     (c.markers.sideA, c.markers.sideB, getDiff c.bodies.sideA c.bodies.sideB)


### PR DESCRIPTION
Evaluating `OverloadedRecordDot` and avoiding record field name prefixes.

This will probably make the code less alien for readers coming from other languages, and imho looks nicer overall.

WDYT?