### PR TITLE
Improve test shell scripts

### DIFF
--- a/test/config/test
+++ b/test/config/test
@@ -6,23 +6,23 @@ cd ${DIR}
 git init
 
 git config --global --unset merge.conflictstyle
-(../${git_mediate} && exit 11) || echo Conflict style unset errorized correctly
+(git-mediate && exit 11) || echo Conflict style unset errorized correctly
 
 git config --global merge.conflictstyle diff2
-(../${git_mediate} && exit 12) || echo Conflict style diff2 errorized correctly
+(git-mediate && exit 12) || echo Conflict style diff2 errorized correctly
 
 git config --global merge.conflictstyle diff3
-../${git_mediate}
+git-mediate
 
 echo diff3 accepted correctly
 
 git config merge.conflictstyle diff2
-(../${git_mediate} && exit 12) || echo Per-project conflict style diff2 errorized correctly
+(git-mediate && exit 12) || echo Per-project conflict style diff2 errorized correctly
 
-(../${git_mediate} -s && exit 12) || echo Per-project conflict style diff2 failure to override errorized correctly
+(git-mediate -s && exit 12) || echo Per-project conflict style diff2 failure to override errorized correctly
 git config --unset merge.conflictstyle
 git config --global merge.conflictstyle diff2
-../${git_mediate} -s
+git-mediate -s
 style=$(git config merge.conflictstyle)
 if [ "$style" == "diff3" ]; then
   echo "Conflict style set correctly"

--- a/test/config/test
+++ b/test/config/test
@@ -24,7 +24,7 @@ git config --unset merge.conflictstyle
 git config --global merge.conflictstyle diff2
 git-mediate -s
 style=$(git config merge.conflictstyle)
-if [ "$style" == "diff3" ]; then
+if [ "$style" = "diff3" ]; then
   echo "Conflict style set correctly"
 else
   echo The '-s' option did not set conflict style

--- a/test/config/test
+++ b/test/config/test
@@ -12,31 +12,31 @@ git init
 git config --global merge.conflictstyle diff3
 git config --global --unset merge.conflictstyle
 (git-mediate && exit 11) ||
-echo Conflict style unset errorized correctly
+echo 'Conflict style unset errorized correctly'
 
 git config --global merge.conflictstyle diff2
 (git-mediate && exit 12) ||
-echo Conflict style diff2 errorized correctly
+echo 'Conflict style diff2 errorized correctly'
 
 git config --global merge.conflictstyle diff3
 git-mediate
 
-echo diff3 accepted correctly
+echo 'diff3 accepted correctly'
 
 git config merge.conflictstyle diff2
 (git-mediate && exit 12) ||
-echo Per-project conflict style diff2 errorized correctly
+echo 'Per-project conflict style diff2 errorized correctly'
 
 (git-mediate -s && exit 12) ||
-echo Per-project conflict style diff2 failure to override errorized correctly
+echo 'Per-project conflict style diff2 failure to override errorized correctly'
 git config --unset merge.conflictstyle
 git config --global merge.conflictstyle diff2
 git-mediate -s
 style=$(git config merge.conflictstyle)
 if [ "${style}" = "diff3" ]; then
-  echo "Conflict style set correctly"
+  echo 'Conflict style set correctly'
 else
-  echo The '-s' option did not set conflict style
+  echo 'The -s option did not set conflict style'
   exit 1
 fi
 

--- a/test/config/test
+++ b/test/config/test
@@ -47,3 +47,5 @@ else
   echo 'The -s option did not set conflict style'
   exit 1
 fi
+
+echo Success

--- a/test/config/test
+++ b/test/config/test
@@ -7,6 +7,8 @@ cd "${DIR}"
 
 export HOME="$(pwd)"
 
+pwd
+
 cleanup () {
   rm -rf .git .gitconfig
 }

--- a/test/config/test
+++ b/test/config/test
@@ -1,7 +1,7 @@
 set -eux
 
 DIR="$( dirname "$0" )"
-cd ${DIR}
+cd "${DIR}"
 
 git init
 

--- a/test/config/test
+++ b/test/config/test
@@ -1,5 +1,4 @@
-set -e
-set -u
+set -eux
 
 DIR="$( dirname "$0" )"
 cd ${DIR}

--- a/test/config/test
+++ b/test/config/test
@@ -3,8 +3,11 @@ set -eux
 DIR="$( dirname "$0" )"
 cd "${DIR}"
 
+export HOME="$(pwd)"
+
 git init
 
+git config --global merge.conflictstyle diff3
 git config --global --unset merge.conflictstyle
 (git-mediate && exit 11) || echo Conflict style unset errorized correctly
 

--- a/test/config/test
+++ b/test/config/test
@@ -9,10 +9,12 @@ git init
 
 git config --global merge.conflictstyle diff3
 git config --global --unset merge.conflictstyle
-(git-mediate && exit 11) || echo Conflict style unset errorized correctly
+(git-mediate && exit 11) ||
+echo Conflict style unset errorized correctly
 
 git config --global merge.conflictstyle diff2
-(git-mediate && exit 12) || echo Conflict style diff2 errorized correctly
+(git-mediate && exit 12) ||
+echo Conflict style diff2 errorized correctly
 
 git config --global merge.conflictstyle diff3
 git-mediate
@@ -20,9 +22,11 @@ git-mediate
 echo diff3 accepted correctly
 
 git config merge.conflictstyle diff2
-(git-mediate && exit 12) || echo Per-project conflict style diff2 errorized correctly
+(git-mediate && exit 12) ||
+echo Per-project conflict style diff2 errorized correctly
 
-(git-mediate -s && exit 12) || echo Per-project conflict style diff2 failure to override errorized correctly
+(git-mediate -s && exit 12) ||
+echo Per-project conflict style diff2 failure to override errorized correctly
 git config --unset merge.conflictstyle
 git config --global merge.conflictstyle diff2
 git-mediate -s

--- a/test/config/test
+++ b/test/config/test
@@ -7,6 +7,12 @@ cd "${DIR}"
 
 export HOME="$(pwd)"
 
+cleanup () {
+  rm -rf .git .gitconfig
+}
+trap cleanup EXIT
+cleanup
+
 git init
 
 git config --global merge.conflictstyle diff3
@@ -39,5 +45,3 @@ else
   echo 'The -s option did not set conflict style'
   exit 1
 fi
-
-rm -rf .git

--- a/test/config/test
+++ b/test/config/test
@@ -24,7 +24,7 @@ git config --unset merge.conflictstyle
 git config --global merge.conflictstyle diff2
 git-mediate -s
 style=$(git config merge.conflictstyle)
-if [ "$style" = "diff3" ]; then
+if [ "${style}" = "diff3" ]; then
   echo "Conflict style set correctly"
 else
   echo The '-s' option did not set conflict style

--- a/test/config/test
+++ b/test/config/test
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 set -eux
 
 DIR="$( dirname "$0" )"

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,4 +1,4 @@
-set -eu
+set -eux
 
 DIR="$( dirname "$0" )"
 

--- a/test/run_tests
+++ b/test/run_tests
@@ -6,13 +6,13 @@ SRC="$( dirname "${DIR}" )"
 export PATH="${SRC}/dist/build/git-mediate:$PATH"
 
 echo Spaces test
-${DIR}/spaces/test
+"${DIR}"/spaces/test
 
 echo Untabify test
-${DIR}/untabify/test
+"${DIR}"/untabify/test
 
 echo Config test
-${DIR}/config/test
+"${DIR}"/config/test
 
 
 echo Tests successful

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,8 +1,9 @@
 set -eux
 
 DIR="$( dirname "$0" )"
+SRC="$( dirname "${DIR}" )"
 
-export git_mediate=../dist/build/git-mediate/git-mediate
+export PATH="${SRC}/dist/build/git-mediate:$PATH"
 
 echo Spaces test
 ${DIR}/spaces/test

--- a/test/run_tests
+++ b/test/run_tests
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 set -eux
 
 DIR="$( dirname "$0" )"

--- a/test/run_tests
+++ b/test/run_tests
@@ -7,14 +7,14 @@ SRC="$( dirname "${DIR}" )"
 
 export PATH="${SRC}/dist/build/git-mediate:$PATH"
 
-echo Spaces test
+echo 'Spaces test'
 "${DIR}"/spaces/test
 
-echo Untabify test
+echo 'Untabify test'
 "${DIR}"/untabify/test
 
-echo Config test
+echo 'Config test'
 "${DIR}"/config/test
 
 
-echo Tests successful
+echo 'Tests successful'

--- a/test/spaces/test
+++ b/test/spaces/test
@@ -3,6 +3,8 @@ set -eux
 DIR="$( dirname "$0" )"
 cd "${DIR}"
 
+export HOME="$(pwd)"
+
 pwd
 rm -rf .git
 
@@ -16,6 +18,7 @@ echo changeA >> 'a b'
 git stash >/dev/null
 echo changeB >> 'a b'
 git add 'a b'
+git config --global merge.conflictstyle diff3
 (git stash pop >/dev/null && exit 1) || echo "Conflict set up successfully"
 # Set up of conflict over
 

--- a/test/spaces/test
+++ b/test/spaces/test
@@ -8,7 +8,12 @@ cd "${DIR}"
 export HOME="$(pwd)"
 
 pwd
-rm -rf .git
+
+cleanup () {
+  rm -rf .git .gitconfig 'a b'
+}
+trap cleanup EXIT
+cleanup
 
 git init >/dev/null
 git config user.email test@test.com
@@ -27,5 +32,3 @@ echo 'Conflict set up successfully'
 
 git-mediate >/dev/null &&
 (echo 'should fail to resolve conflicts' ; exit 1)
-
-rm -rf .git 'a b'

--- a/test/spaces/test
+++ b/test/spaces/test
@@ -1,7 +1,7 @@
 set -eux
 
 DIR="$( dirname "$0" )"
-cd ${DIR}
+cd "${DIR}"
 
 pwd
 rm -rf .git

--- a/test/spaces/test
+++ b/test/spaces/test
@@ -32,3 +32,5 @@ echo 'Conflict set up successfully'
 
 git-mediate >/dev/null &&
 (echo 'should fail to resolve conflicts' ; exit 1)
+
+echo Success

--- a/test/spaces/test
+++ b/test/spaces/test
@@ -15,17 +15,17 @@ git config user.email test@test.com
 git config user.name Test
 echo hi > 'a b'
 git add -- 'a b'
-git commit -m"a b file added" >/dev/null
+git commit -m'a b file added' >/dev/null
 echo changeA >> 'a b'
 git stash >/dev/null
 echo changeB >> 'a b'
 git add 'a b'
 git config --global merge.conflictstyle diff3
 (git stash pop >/dev/null && exit 1) ||
-echo "Conflict set up successfully"
+echo 'Conflict set up successfully'
 # Set up of conflict over
 
 git-mediate >/dev/null &&
-(echo should fail to resolve conflicts ; exit 1)
+(echo 'should fail to resolve conflicts' ; exit 1)
 
 rm -rf .git 'a b'

--- a/test/spaces/test
+++ b/test/spaces/test
@@ -19,6 +19,6 @@ git add 'a b'
 (git stash pop >/dev/null && exit 1) || echo "Conflict set up successfully"
 # Set up of conflict over
 
-../${git_mediate} >/dev/null && (echo should fail to resolve conflicts ; exit 1)
+git-mediate >/dev/null && (echo should fail to resolve conflicts ; exit 1)
 
 rm -rf .git 'a b'

--- a/test/spaces/test
+++ b/test/spaces/test
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 set -eux
 
 DIR="$( dirname "$0" )"

--- a/test/spaces/test
+++ b/test/spaces/test
@@ -19,9 +19,11 @@ git stash >/dev/null
 echo changeB >> 'a b'
 git add 'a b'
 git config --global merge.conflictstyle diff3
-(git stash pop >/dev/null && exit 1) || echo "Conflict set up successfully"
+(git stash pop >/dev/null && exit 1) ||
+echo "Conflict set up successfully"
 # Set up of conflict over
 
-git-mediate >/dev/null && (echo should fail to resolve conflicts ; exit 1)
+git-mediate >/dev/null &&
+(echo should fail to resolve conflicts ; exit 1)
 
 rm -rf .git 'a b'

--- a/test/untabify/test
+++ b/test/untabify/test
@@ -1,4 +1,4 @@
-set -eu
+set -eux
 
 DIR="$( dirname "$0" )"
 cd ${DIR}

--- a/test/untabify/test
+++ b/test/untabify/test
@@ -31,3 +31,5 @@ echo 'Conflict set up successfully'
 # Set up of conflict over
 
 git-mediate --untabify=4
+
+echo Success

--- a/test/untabify/test
+++ b/test/untabify/test
@@ -1,7 +1,7 @@
 set -eux
 
 DIR="$( dirname "$0" )"
-cd ${DIR}
+cd "${DIR}"
 
 pwd
 rm -rf .git

--- a/test/untabify/test
+++ b/test/untabify/test
@@ -19,6 +19,6 @@ git add file
 (git stash pop >/dev/null && exit 1) || echo "Conflict set up successfully"
 # Set up of conflict over
 
-../${git_mediate} --untabify=4
+git-mediate --untabify=4
 
 rm -rf .git file

--- a/test/untabify/test
+++ b/test/untabify/test
@@ -15,14 +15,14 @@ git config user.email test@test.com
 git config user.name Test
 printf 'Hello\tBooya\n' > file
 git add -- file
-git commit -m"tabs" >/dev/null
+git commit -m'tabs' >/dev/null
 echo 'Extra line' >> file
 git stash >/dev/null
 echo 'Hello   Booya' > file
 git add file
 git config --global merge.conflictstyle diff3
 (git stash pop >/dev/null && exit 1) ||
-echo "Conflict set up successfully"
+echo 'Conflict set up successfully'
 # Set up of conflict over
 
 git-mediate --untabify=4

--- a/test/untabify/test
+++ b/test/untabify/test
@@ -8,7 +8,12 @@ cd "${DIR}"
 export HOME="$(pwd)"
 
 pwd
-rm -rf .git
+
+cleanup () {
+  rm -rf .git .gitconfig file
+}
+trap cleanup EXIT
+cleanup
 
 git init >/dev/null
 git config user.email test@test.com
@@ -26,5 +31,3 @@ echo 'Conflict set up successfully'
 # Set up of conflict over
 
 git-mediate --untabify=4
-
-rm -rf .git file

--- a/test/untabify/test
+++ b/test/untabify/test
@@ -19,7 +19,8 @@ git stash >/dev/null
 echo 'Hello   Booya' > file
 git add file
 git config --global merge.conflictstyle diff3
-(git stash pop >/dev/null && exit 1) || echo "Conflict set up successfully"
+(git stash pop >/dev/null && exit 1) ||
+echo "Conflict set up successfully"
 # Set up of conflict over
 
 git-mediate --untabify=4

--- a/test/untabify/test
+++ b/test/untabify/test
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 set -eux
 
 DIR="$( dirname "$0" )"

--- a/test/untabify/test
+++ b/test/untabify/test
@@ -3,6 +3,8 @@ set -eux
 DIR="$( dirname "$0" )"
 cd "${DIR}"
 
+export HOME="$(pwd)"
+
 pwd
 rm -rf .git
 
@@ -16,6 +18,7 @@ echo 'Extra line' >> file
 git stash >/dev/null
 echo 'Hello   Booya' > file
 git add file
+git config --global merge.conflictstyle diff3
 (git stash pop >/dev/null && exit 1) || echo "Conflict set up successfully"
 # Set up of conflict over
 


### PR DESCRIPTION
- Standardise on `set -eux` for all test shell scripts
- Run git-mediate via `$PATH` instead of a location stored in a variable
- Avoid passing options to echo
- Use `=` instead of `==` within `[ ]` tests
- Quote references to shell variables
- Use braces around references to shell variables
- Set the test user home directory to the test directories
- Wrap multi-command shell statements more
- Add shebangs to the shell scripts
- Consistently single-quote static strings containing spaces
- Ensure the tests run in a clean directory and clean it on exit
- Print the current directory in all tests for consistency
- Indicate successful completion of tests
